### PR TITLE
Fixed typo in SubInstruction

### DIFF
--- a/Server/src/main/java/net/simon987/server/assembly/instruction/SubInstruction.java
+++ b/Server/src/main/java/net/simon987/server/assembly/instruction/SubInstruction.java
@@ -29,7 +29,7 @@ public class SubInstruction extends Instruction {
 
         status.setSignFlag(Util.checkSign16(result));
         status.setZeroFlag((char) result == 0);
-        status.setOverflowFlag(Util.checkOverFlowAdd16(a, b));
+        status.setOverflowFlag(Util.checkOverFlowSub16(a, b));
         status.setCarryFlag(Util.checkCarry16(result));
 
         dst.set(dstIndex, result);


### PR DESCRIPTION
The first execute block for SubInstruction was using the checkOverFlowAdd function whereas the 2nd one was using checkOverFlowSub.