### PR TITLE
Allow ability to damage NPCs with Laser #34

### DIFF
--- a/Plugin Cubot/src/main/java/net/simon987/cubotplugin/CubotLaser.java
+++ b/Plugin Cubot/src/main/java/net/simon987/cubotplugin/CubotLaser.java
@@ -6,6 +6,7 @@ import net.simon987.server.assembly.Status;
 import net.simon987.server.game.Action;
 import net.simon987.server.game.GameObject;
 import net.simon987.server.game.InventoryHolder;
+import net.simon987.server.game.Attackable;
 import org.json.simple.JSONObject;
 
 import java.awt.*;
@@ -24,7 +25,9 @@ public class CubotLaser extends CpuHardware {
 
     private static final int LASER_WITHDRAW = 1;
     private static final int LASER_DEPOSIT = 2;
+    private static final int LASER_ATTACK = 3;
 
+    private static final int LASER_DAMAGE = 20;
 
     public CubotLaser(Cubot cubot) {
         this.cubot = cubot;
@@ -67,6 +70,20 @@ public class CubotLaser extends CpuHardware {
 
         } else if (a == LASER_DEPOSIT) {
             // TODO
+        } else if (a == LASER_ATTACK) {
+           
+            if (cubot.spendEnergy(20)) {
+                
+                //Get object directly in front of the Cubot
+                Point frontTile = cubot.getFrontTile();
+                ArrayList<GameObject> objects = cubot.getWorld().getGameObjectsAt(frontTile.x, frontTile.y);
+
+                if (objects.size() > 0 && objects.get(0) instanceof Attackable) {
+                    ((Attackable) objects.get(0)).damage(LASER_DAMAGE);
+                }
+
+            }
+
         }
 
     }

--- a/Plugin NPC/src/main/java/net/simon987/npcplugin/HarvesterNPC.java
+++ b/Plugin NPC/src/main/java/net/simon987/npcplugin/HarvesterNPC.java
@@ -8,10 +8,16 @@ public class HarvesterNPC extends NonPlayerCharacter {
 
     public static final int ID = 10;
 
+    public static final int MAX_HEALTH = 100;
+    public static final int HEAL_RATE = 5;
+
 
     public HarvesterNPC() {
         setTask(new HarvestTask());
-        hp = 10;
+
+        setHp(MAX_HEALTH);
+        setMaxHp(MAX_HEALTH);
+        setHealRate(HEAL_RATE);
     }
 
     @Override
@@ -44,7 +50,7 @@ public class HarvesterNPC extends NonPlayerCharacter {
         json.put("x", getX());
         json.put("y", getY());
         json.put("direction", getDirection().ordinal());
-        json.put("hp", hp);
+        json.put("hp", getHp());
         json.put("energy", energy);
         json.put("action", getAction().ordinal());
         json.put("t", ID);
@@ -58,7 +64,7 @@ public class HarvesterNPC extends NonPlayerCharacter {
         npc.setObjectId((long) json.get("i"));
         npc.setX((int) (long) json.get("x"));
         npc.setY((int) (long) json.get("y"));
-        npc.hp = (int) (long) json.get("hp");
+        npc.setHp((int) (long) json.get("hp"));
         npc.setDirection(Direction.getDirection((int) (long) json.get("direction")));
         npc.energy = (int) (long) json.get("energy");
         npc.maxEnergy = GameServer.INSTANCE.getConfig().getInt("battery_max_energy");

--- a/Plugin NPC/src/main/java/net/simon987/npcplugin/NonPlayerCharacter.java
+++ b/Plugin NPC/src/main/java/net/simon987/npcplugin/NonPlayerCharacter.java
@@ -6,13 +6,14 @@ import net.simon987.server.game.Action;
 import net.simon987.server.game.Direction;
 import net.simon987.server.game.GameObject;
 import net.simon987.server.game.Updatable;
+import net.simon987.server.game.Attackable;
 import net.simon987.server.game.pathfinding.Node;
 import net.simon987.server.game.pathfinding.Pathfinder;
 import net.simon987.server.logging.LogManager;
 
 import java.util.ArrayList;
 
-public abstract class NonPlayerCharacter extends GameObject implements Updatable {
+public abstract class NonPlayerCharacter extends GameObject implements Updatable, Attackable {
 
     private static final int MAP_INFO = 0x0040;
 
@@ -20,8 +21,11 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
 
     public static final int LIFETIME = GameServer.INSTANCE.getConfig().getInt("npc_lifetime");
 
+    // Set these just in case they aren't overridden in the subclass
+    public static final int HP_MAX_DEFAULT = 100;
+    public static final int HP_REGEN_RATE_DEFAULT = 5;
+
     //Unused
-    int hp;
     int energy;
     int maxEnergy;
 
@@ -48,6 +52,21 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
      */
     private int age = 0;
 
+    /**
+     * Current health of the npc
+     */
+    private int hp = HP_MAX_DEFAULT;
+
+    /**
+     * Health regeneration rate of the npc
+     */
+    private int hpRegenerationRate = HP_REGEN_RATE_DEFAULT;
+
+    /**
+     * Maximum health of the npc
+     */
+    private int maxHp = HP_MAX_DEFAULT;
+
     @Override
     public char getMapInfo() {
         return MAP_INFO;
@@ -66,6 +85,9 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
 
             selfDestroyNextTick = true;
         }
+
+        //Heal the NPC
+        heal(hpRegenerationRate);
     }
 
     /**
@@ -155,6 +177,52 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
             }
         } else {
             return false;
+        }
+    }
+
+    @Override
+    public void setHealRate(int hp) {
+        hpRegenerationRate = hp;
+    }
+
+    @Override
+    public int getHp() {
+        return hp;
+    }
+
+    @Override
+    public void setHp(int hp) {
+        this.hp = hp;
+    }
+
+    @Override
+    public int getMaxHp() {
+        return maxHp;
+    }
+
+    @Override
+    public void setMaxHp(int hp) {
+        this.maxHp = hp;
+        this.hp = hp;
+    }
+
+    @Override
+    public void heal(int amount) {
+        hp += amount;
+
+        //Can't heal above max
+        if (hp > maxHp) {
+            hp = maxHp;
+        }
+    }
+
+    @Override
+    public void damage(int amount) {
+        hp -= amount;
+
+        //YOU ARE DEAD
+        if (hp <= 0) {
+            setDead(true);
         }
     }
 

--- a/Server/src/main/java/net/simon987/server/game/Attackable.java
+++ b/Server/src/main/java/net/simon987/server/game/Attackable.java
@@ -1,0 +1,19 @@
+package net.simon987.server.game;
+
+/**
+ * Objects that can be attacked or healed
+ */
+public interface Attackable {
+
+    void setHealRate(int hp);
+
+    int getHp();
+    void setHp(int hp);
+
+    int getMaxHp();
+    void setMaxHp(int hp);
+
+    void heal(int amount);
+    void damage(int amount);
+
+}


### PR DESCRIPTION
Addresses issue #34.

* Adds Attackable interface for objects with HP that are able to be attacked.
* Adds LASER_ATTACK function that deals 20 damage.
* Harvester NPCs now have 100 hp, heal at a rate of 5 hp per tick, and are killed if they hit 0 HP.