### PR TITLE
Added jump/warp movement, animation needs changing

### DIFF
--- a/Plugin Cubot/src/main/java/net/simon987/cubotplugin/Cubot.java
+++ b/Plugin Cubot/src/main/java/net/simon987/cubotplugin/Cubot.java
@@ -40,6 +40,8 @@ public class Cubot extends GameObject implements Updatable, ControllableUnit, Pr
     private int energy;
     private int maxEnergy;
 
+    private int jumpDistance;
+
     private static final float SOLAR_PANEL_MULTIPLIER = 1;
     private static final int CONSOLE_BUFFER_MAX_SIZE = 40;
 
@@ -59,8 +61,17 @@ public class Cubot extends GameObject implements Updatable, ControllableUnit, Pr
 
         if (currentAction == Action.WALKING) {
             if (spendEnergy(100)) {
-                if (!incrementLocation()) {
+                if (!incrementLocation(1)) {
                     //Couldn't walk
+                    currentAction = Action.IDLE;
+                }
+            } else {
+                currentAction = Action.IDLE;
+            }
+        } else if (currentAction == Action.JUMPING) {
+            if (spendEnergy(jumpDistance * 200)) {
+                if (!incrementLocation(jumpDistance)) {
+                    //Couldn't jump
                     currentAction = Action.IDLE;
                 }
             } else {
@@ -134,6 +145,10 @@ public class Cubot extends GameObject implements Updatable, ControllableUnit, Pr
 
     public int getHeldItem() {
         return heldItem;
+    }
+
+    public void setJumpDistance(int jumpDistance) {
+        this.jumpDistance = jumpDistance;
     }
 
     @Override

--- a/Plugin Cubot/src/main/java/net/simon987/cubotplugin/CubotLeg.java
+++ b/Plugin Cubot/src/main/java/net/simon987/cubotplugin/CubotLeg.java
@@ -16,6 +16,7 @@ public class CubotLeg extends CpuHardware implements JSONSerialisable {
 
     private static final int LEGS_SET_DIR = 1;
     private static final int LEGS_SET_DIR_AND_WALK = 2;
+    private static final int LEGS_JUMP = 3;
 
     /**
      * Hardware ID (Should be unique)
@@ -66,6 +67,12 @@ public class CubotLeg extends CpuHardware implements JSONSerialisable {
                 }
 
                 cubot.setCurrentAction(Action.WALKING);
+            }
+        } else if (a == LEGS_JUMP) {
+            // jump up to 3 spaces, each space costs 200
+            if (b < 4 && cubot.getMaxEnergy() >= b * 200) {
+                cubot.setJumpDistance(b);
+                cubot.setCurrentAction(Action.JUMPING);
             }
         }
     }

--- a/Plugin NPC/src/main/java/net/simon987/npcplugin/NonPlayerCharacter.java
+++ b/Plugin NPC/src/main/java/net/simon987/npcplugin/NonPlayerCharacter.java
@@ -90,7 +90,7 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
                 LogManager.LOGGER.severe("FIXME: moveTo:NonPlayerCharacter, Direction is null");
             }
 
-            if (incrementLocation()) {
+            if (incrementLocation(1)) {
                 lastAction = Action.WALKING;
                 return true;
             }
@@ -113,7 +113,7 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
                     getWorld().getX(), getWorld().getY() - 1) <= MAX_FACTORY_DISTANCE) {
                 if (!moveTo(8, 0, 0)) {
                     setDirection(Direction.NORTH);
-                    incrementLocation();
+                    incrementLocation(1);
                 }
                 return true;
             } else {
@@ -125,7 +125,7 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
                     getWorld().getX() + 1, getWorld().getY()) <= MAX_FACTORY_DISTANCE) {
                 if (!moveTo(15, 7, 0)) {
                     setDirection(Direction.EAST);
-                    incrementLocation();
+                    incrementLocation(1);
                 }
                 return true;
             } else {
@@ -136,7 +136,7 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
                     getWorld().getX(), getWorld().getY() + 1) <= MAX_FACTORY_DISTANCE) {
                 if (!moveTo(8, 15, 0)) {
                     setDirection(Direction.SOUTH);
-                    incrementLocation();
+                    incrementLocation(1);
                 }
                 return true;
             } else {
@@ -147,7 +147,7 @@ public abstract class NonPlayerCharacter extends GameObject implements Updatable
                     getWorld().getX() - 1, getWorld().getY()) <= MAX_FACTORY_DISTANCE) {
                 if (!moveTo(0, 7, 0)) {
                     setDirection(Direction.WEST);
-                    incrementLocation();
+                    incrementLocation(1);
                 }
                 return true;
             } else {

--- a/Server/src/main/java/net/simon987/server/game/Action.java
+++ b/Server/src/main/java/net/simon987/server/game/Action.java
@@ -6,6 +6,7 @@ public enum Action {
     WALKING,
     WITHDRAWING,
     DEPOSITING,
-    LISTENING
+    LISTENING,
+    JUMPING
 
 }

--- a/Server/src/main/java/net/simon987/server/game/GameObject.java
+++ b/Server/src/main/java/net/simon987/server/game/GameObject.java
@@ -47,24 +47,24 @@ public abstract class GameObject implements JSONSerialisable {
      * Increment the location of the game object by 1 tile
      * Collision checks happen here
      */
-    public boolean incrementLocation() {
+    public boolean incrementLocation(int distance) {
 
         int newX = 0, newY = 0;
 
         if (direction == Direction.NORTH) {
             newX = x;
-            newY = (y - 1);
+            newY = (y - distance);
 
         } else if (direction == Direction.EAST) {
-            newX = (x + 1);
+            newX = (x + distance);
             newY = y;
 
         } else if (direction == Direction.SOUTH) {
             newX = x;
-            newY = (y + 1);
+            newY = (y + distance);
 
         } else if (direction == Direction.WEST) {
-            newX = (x - 1);
+            newX = (x - distance);
             newY = y;
         }
 
@@ -81,13 +81,17 @@ public abstract class GameObject implements JSONSerialisable {
             }
 
             if (leftWorld != null) {
-                world.getGameObjects().remove(this);
-                world.decUpdatable();
-                leftWorld.getGameObjects().add(this);
-                leftWorld.incUpdatable();
-                setWorld(leftWorld);
+                if(!leftWorld.isTileBlocked(World.WORLD_SIZE+newX, newY)) {
+                    world.getGameObjects().remove(this);
+                    world.decUpdatable();
+                    leftWorld.getGameObjects().add(this);
+                    leftWorld.incUpdatable();
+                    setWorld(leftWorld);
 
-                x = World.WORLD_SIZE - 1;
+                    x = World.WORLD_SIZE + newX;
+                } else if (distance > 1) {
+                    return incrementLocation(distance-1);
+                }
             }
         } else if (newX >= World.WORLD_SIZE) {
             //Move object to adjacent World (right)
@@ -100,13 +104,17 @@ public abstract class GameObject implements JSONSerialisable {
             }
 
             if (rightWorld != null) {
-                world.getGameObjects().remove(this);
-                world.decUpdatable();
-                rightWorld.getGameObjects().add(this);
-                rightWorld.incUpdatable();
-                setWorld(rightWorld);
+                if(!rightWorld.isTileBlocked(newX-World.WORLD_SIZE, y)) {
+                    world.getGameObjects().remove(this);
+                    world.decUpdatable();
+                    rightWorld.getGameObjects().add(this);
+                    rightWorld.incUpdatable();
+                    setWorld(rightWorld);
 
-                x = 0;
+                    x = newX - World.WORLD_SIZE;
+                } else if (distance > 1) {
+                    return incrementLocation(distance-1);
+                }
             }
         } else if (newY < 0) {
             //Move object to adjacent World (up)
@@ -120,13 +128,17 @@ public abstract class GameObject implements JSONSerialisable {
             }
 
             if (upWorld != null) {
-                world.getGameObjects().remove(this);
-                world.decUpdatable();
-                upWorld.getGameObjects().add(this);
-                upWorld.incUpdatable();
-                setWorld(upWorld);
+                if (!upWorld.isTileBlocked(x, World.WORLD_SIZE+newY)) {
+                    world.getGameObjects().remove(this);
+                    world.decUpdatable();
+                    upWorld.getGameObjects().add(this);
+                    upWorld.incUpdatable();
+                    setWorld(upWorld);
 
-                y = World.WORLD_SIZE - 1;
+                    y = World.WORLD_SIZE + newY;
+                } else if (distance > 1) {
+                    return incrementLocation(distance-1);
+                }
             }
         } else if (newY >= World.WORLD_SIZE) {
             //Move object to adjacent World (down)
@@ -140,13 +152,17 @@ public abstract class GameObject implements JSONSerialisable {
 
 
             if (downWorld != null) {
-                world.getGameObjects().remove(this);
-                world.decUpdatable();
-                downWorld.getGameObjects().add(this);
-                downWorld.incUpdatable();
-                setWorld(downWorld);
+                if (!downWorld.isTileBlocked(x,newY-World.WORLD_SIZE)) {
+                    world.getGameObjects().remove(this);
+                    world.decUpdatable();
+                    downWorld.getGameObjects().add(this);
+                    downWorld.incUpdatable();
+                    setWorld(downWorld);
 
-                y = 0;
+                    y = newY - World.WORLD_SIZE;
+                } else if (distance > 1) {
+                    return incrementLocation(distance-1);
+                }
             }
         }
         //Check collision
@@ -154,7 +170,9 @@ public abstract class GameObject implements JSONSerialisable {
             //Tile is passable
             x = newX;
             y = newY;
-        } else {
+        } else if (distance > 1) {
+            return incrementLocation(distance-1);
+        }else {
             return false;
         }
 


### PR DESCRIPTION
Addressing issue #45 

- Allows attempts to jump 0/1/2/3 spaces, using distance * 200 energy.
- Distance in B register.
- Animation currently just walks real fast and through objects.
- Can't land on a blocked square.
- Can travel over blocked squares.
- If landing square is blocked, attempts to jump distance-1 instead (energy cost is determined at initial jump attempt)