### PR TITLE
Added minimum length check to 'DW' parsing

### DIFF
--- a/Server/src/main/java/net/simon987/server/assembly/Assembler.java
+++ b/Server/src/main/java/net/simon987/server/assembly/Assembler.java
@@ -132,7 +132,7 @@ public class Assembler {
 
         //System.out.println(line);
 
-        if (line.substring(0, 2).toUpperCase().equals("DW")) {
+        if (line.length() >= 2 && line.substring(0, 2).toUpperCase().equals("DW")) {
 
             try {
 


### PR DESCRIPTION
Fixes https://github.com/simon987/Much-Assembly-Required/issues/81 
Though the assembler will keep going and ignore the unknown pneumonic "D", which seems like a different bug, since null is being returned as desired.
`[01/01 05:15:17:671] [SEVERE] Unknown mnemonic "D"@0`
