### PR TITLE
Added handling of offset overflow and DUP factor overflow

### DIFF
--- a/Server/src/main/java/net/simon987/server/assembly/exception/FatalAssemblyException.java
+++ b/Server/src/main/java/net/simon987/server/assembly/exception/FatalAssemblyException.java
@@ -1,0 +1,20 @@
+package net.simon987.server.assembly.exception;
+
+/**
+ * Class of exceptions that should stop assembly immediatly 
+ */
+public class FatalAssemblyException extends AssemblyException {
+
+    /**
+     * Message of the exception
+     */
+    private static final String message = "A fatal assembly error has occurred";
+
+    /**
+     * Create a new Duplicate Segment Exception
+     */
+    public FatalAssemblyException(String msg, int line) {
+        super(msg, line);
+    }
+}
+

--- a/Server/src/main/java/net/simon987/server/assembly/exception/OffsetOverflowException.java
+++ b/Server/src/main/java/net/simon987/server/assembly/exception/OffsetOverflowException.java
@@ -1,0 +1,19 @@
+package net.simon987.server.assembly.exception;
+
+/**
+ * Threw when offset for stored instruction/data overflows the size of memory
+ */
+public class OffsetOverflowException extends FatalAssemblyException {
+
+    /**
+     * Message of the exception
+     */
+    private static final String message = "Program data exceeds memory size ";
+
+    /**
+     * Create a new Offset Overflow Exception
+     */
+    public OffsetOverflowException(int offset, int memsiz, int line) {
+        super(message + offset + " > " + memsiz, line);
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/simon987/Much-Assembly-Required/issues/80

Added check for factor on `DUP`, limiting to RAM_SIZE (0x10000 words).
Added check during pass 3 of assembly if the current offset exceeds the RAM_SIZE to throw a fatal exception (OffsetOverflowException) and stop further assembly of text.
Added new class of exceptions FatalAssemblyException which will halt assembly once thrown and not attempt to assemble subsequent lines.