### PR TITLE
Updated LogManager

### DIFF
--- a/Server/src/main/java/net/simon987/server/logging/LogManager.java
+++ b/Server/src/main/java/net/simon987/server/logging/LogManager.java
@@ -19,9 +19,30 @@ public class LogManager {
     public static void initialize() {
         LOGGER.setUseParentHandlers(false);
 
-        Handler handler = new ConsoleHandler();
+        /*
+        * Having warning/error directed to stderr
+        */
+        Handler errHandler = new ConsoleHandler();
+        errHandler.setFormatter(new GenericFormatter());
+        errHandler.setLevel(Level.WARNING);
+
+        /*
+        * Only have info and below directed to stdout
+        */
+        Handler handler = new StreamHandler(System.out, new GenericFormatter()) {
+            @Override
+            public synchronized void publish(LogRecord record) {
+                super.publish(record);
+                flush();
+            }
+        };
+        handler.setFilter(new Filter() {
+            @Override
+            public boolean isLoggable(LogRecord record) {
+                return record.getLevel().intValue() <= Level.INFO.intValue();
+            }
+        });
         handler.setLevel(Level.ALL);
-        handler.setFormatter(new GenericFormatter());
 
         try {
             Handler fileHandler = new FileHandler("mar.log");
@@ -29,13 +50,13 @@ public class LogManager {
             fileHandler.setFormatter(new GenericFormatter());
 
             LOGGER.addHandler(handler);
+            LOGGER.addHandler(errHandler);
             LOGGER.addHandler(fileHandler);
             LOGGER.setLevel(Level.ALL);
 
         } catch (IOException e) {
             e.printStackTrace();
         }
-
 
     }
 }


### PR DESCRIPTION
Changed so that only warning/severe are directed to stderr, everything of level info and below are directed to stdout. This does not change how the output looks if the server is run from the command line, it will only make a noticeable difference if you are redirecting stdout and/or stderr manually.

The override of publish is to emulate the functionality of [ConsoleHandler](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/logging/ConsoleHandler.java#ConsoleHandler.publish%28java.util.logging.LogRecord%29) automatically flushing the output. 

The filter is to make it so that warning/severe are not written to stdout.