### PR TITLE
Fix assembler crash when invalid Unicode string escape sequences are used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Server/src/main/java/META-INF/MANIFEST.MF
 .settings
 .project
 .classpath
+# VSCode Workspace
+.vscode/

--- a/Server/src/main/java/net/simon987/server/assembly/Assembler.java
+++ b/Server/src/main/java/net/simon987/server/assembly/Assembler.java
@@ -156,7 +156,14 @@ public class Assembler {
 
                         //Unescape the string
                         String string = value.substring(1, value.length() - 1);
-                        string = StringEscapeUtils.unescapeJava(string);
+
+                        try {
+                            string = StringEscapeUtils.unescapeJava(string);
+                        } catch (IllegalArgumentException e) {
+                            throw new InvalidOperandException(
+                                "Invalid string operand \"" + string + "\": " + e.getMessage(), 
+                                currentLine);
+                        }
 
                         out.write(string.getBytes(StandardCharsets.UTF_16BE));
                     } else if (labels != null && labels.containsKey(value)) {


### PR DESCRIPTION
- Also includes an addition to .gitignore to ignore Visual Studio Code workspaces from the repo. I personally use this, figured it would be good to add for future contributors to make sure no one accidentally commits it 😄.