### PR TITLE
Issue 172

### DIFF
--- a/Server/src/main/java/net/simon987/server/assembly/Operand.java
+++ b/Server/src/main/java/net/simon987/server/assembly/Operand.java
@@ -216,7 +216,7 @@ public class Operand {
 
                 Character address = labels.get(expr.replaceAll("[^A-Za-z0-9_]", ""));
                 if (address != null) {
-                    data = address;
+                    data = (expr.startsWith("-")) ? -address : address;
                     value += registerSet.size() * 2;//refers to memory with disp
 
                     return true;

--- a/Server/src/test/java/net/simon987/server/assembly/OperandTest.java
+++ b/Server/src/test/java/net/simon987/server/assembly/OperandTest.java
@@ -116,6 +116,11 @@ public class OperandTest {
             assertEquals(8 + 2 * registerSet.size(), mem9.getValue());
             assertEquals(1, mem9.getData());
 
+            Operand mem10 = new Operand("[   B -    label1     ]", labels, registerSet, 0);
+            assertEquals(OperandType.MEMORY_REG_DISP16, mem10.getType());
+            assertEquals(2 + 2 * registerSet.size(), mem10.getValue());
+            assertEquals(-10, mem10.getData());
+
 
         } catch (InvalidOperandException e) {
             fail("Failed trying to parse a valid operand");


### PR DESCRIPTION
#172 I also added a test case to check that it would fail before the fix.  It did fail initially as expected and then changed the assignment of data to `data = (expr.startsWith("-")) ? -address : address;` and it passed the test case.