### PR TITLE
fix faulty object property name

### DIFF
--- a/Server/src/main/typescript/GameClient.ts
+++ b/Server/src/main/typescript/GameClient.ts
@@ -84,7 +84,7 @@ class TickListener implements MessageListener {
         }
 
         //Update console screen
-        if (message.c != undefined) {
+        if (message.console_message_buffer != undefined) {
             mar.client.consoleScreen.handleConsoleBufferUpdate(
                 message.console_message_buffer,
                 message.console_mode as ConsoleMode);


### PR DESCRIPTION
The console is broken in the live environment. Seems like a missing rename in the client side code.