### PR TITLE
Radioactive Game Object onto Map

### DIFF
--- a/Plugin Plant/src/main/java/net/simon987/biomassplugin/WorldUtils.java
+++ b/Plugin Plant/src/main/java/net/simon987/biomassplugin/WorldUtils.java
@@ -20,8 +20,9 @@ public class WorldUtils {
         int blobCount = random.nextInt(maxCount - minCount) + minCount;
         ArrayList<BiomassBlob> biomassBlobs = new ArrayList<>(blobCount);
 
-        //Count number of plain tiles. If there is less plain tiles than desired amount of blobs,
-        //set the desired amount of blobs to the plain tile count
+        // Count number of plain tiles. If there is less plain tiles than desired amount
+        // of blobs,
+        // set the desired amount of blobs to the plain tile count
         TileMap m = world.getTileMap();
         int plainCount = 0;
         for (int y = 0; y < world.getWorldSize(); y++) {
@@ -37,16 +38,15 @@ public class WorldUtils {
             blobCount = plainCount;
         }
 
-        outerLoop:
-        for (int i = 0; i < blobCount; i++) {
+        outerLoop: for (int i = 0; i < blobCount; i++) {
 
             Point p = m.getRandomTile(TilePlain.ID);
             if (p != null) {
 
-                //Don't block worlds
+                // Don't block worlds
                 int counter = 0;
-                while (p.x == 0 || p.y == 0 || p.x == world.getWorldSize() - 1 || p.y == world.getWorldSize() - 1 ||
-                        world.getGameObjectsAt(p.x, p.y).size() != 0) {
+                while (p.x == 0 || p.y == 0 || p.x == world.getWorldSize() - 1 || p.y == world.getWorldSize() - 1
+                        || world.getGameObjectsAt(p.x, p.y).size() != 0) {
                     p = m.getRandomTile(TilePlain.ID);
                     counter++;
 
@@ -57,7 +57,7 @@ public class WorldUtils {
 
                 for (BiomassBlob biomassBlob : biomassBlobs) {
                     if (biomassBlob.getX() == p.x && biomassBlob.getY() == p.y) {
-                        //There is already a blob here
+                        // There is already a blob here
                         continue outerLoop;
                     }
                 }

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
@@ -13,6 +13,7 @@ import net.simon987.server.game.objects.Radioactive;
 
 public class RadiationDetector extends HardwareModule {
 
+  // NEEDS TO BE CHANGED
   // Need to change to whatever the last unique address is
   public static final int DEFAULT_ADDRESS = 0x010F;
 
@@ -20,11 +21,6 @@ public class RadiationDetector extends HardwareModule {
    * Hardware ID (Should be unique) -- NEEDS TO BE CHANGED
    */
   public static final char HWID = 0x010F;
-
-  /**
-   * Radiation detected by cubot
-   */
-  private double currentRadiation = 0;
 
   /**
    * Helper class for getTiles
@@ -119,16 +115,10 @@ public class RadiationDetector extends HardwareModule {
 
   public RadiationDetector(ControllableUnit unit) {
     super(null, unit);
-
-    // Set default values
-    currentRadiation = 0;
   }
 
   public RadiationDetector(Document document, ControllableUnit cubot) {
     super(document, cubot);
-
-    // Set default values
-    currentRadiation = 0;
   }
 
   @Override

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
@@ -1,0 +1,89 @@
+package net.simon987.pluginradioactivecloud;
+
+import java.util.HashSet;
+
+import org.bson.Document;
+import net.simon987.server.assembly.HardwareModule;
+import net.simon987.server.assembly.Status;
+import net.simon987.server.game.objects.ControllableUnit;
+
+public class RadiationDetector extends HardwareModule {
+
+  // Need to change to whatever the last unique address is
+  public static final int DEFAULT_ADDRESS = 0x010F;
+
+  /**
+   * Hardware ID (Should be unique) -- NEEDS TO BE CHANGED
+   */
+  public static final char HWID = 0x010F;
+
+  /**
+   * Radiation detected by cubot
+   */
+  private double currentRadiation = 0;
+
+  /**
+   * Helper class for getTiles
+   */
+  private class Tuple {
+    public final int x;
+    public final int y;
+
+    public Tuple(int x, int y) {
+      this.x = x;
+      this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+
+      if (!(o instanceof Tuple)) {
+        return false;
+      }
+
+      Tuple t = (Tuple) o;
+
+      return Integer.compare(x, t.x) == 0 && Integer.compare(y, t.y) == 0;
+    }
+  }
+
+  /**
+   * Find tiles between two given tiles.
+   */
+  private HashSet<Tuple> getTiles(int x0, int y0, int x1, int y1) {
+
+    HashSet<Tuple> ret = new HashSet<>();
+    double slope = (y1 - y0) / (double) (x1 - x0);
+
+    return ret;
+  }
+
+  public RadiationDetector(ControllableUnit unit) {
+    super(null, unit);
+
+    // Set default values
+    currentRadiation = 0;
+  }
+
+  public RadiationDetector(Document document, ControllableUnit cubot) {
+    super(document, cubot);
+
+    // Set default values
+    currentRadiation = 0;
+  }
+
+  @Override
+  public void handleInterrupt(Status status) {
+
+    // Fill in
+  }
+
+  @Override
+  public char getId() {
+    return HWID;
+  }
+
+}

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
@@ -2,8 +2,6 @@ package net.simon987.pluginradioactivecloud;
 
 import java.util.ArrayList;
 
-import javax.lang.model.type.UnionType;
-
 import org.bson.Document;
 import net.simon987.server.assembly.HardwareModule;
 import net.simon987.server.assembly.Status;
@@ -13,14 +11,15 @@ import net.simon987.server.game.objects.Radioactive;
 
 public class RadiationDetector extends HardwareModule {
 
-  // NEEDS TO BE CHANGED
-  // Need to change to whatever the last unique address is
-  public static final int DEFAULT_ADDRESS = 0x010F;
+  /**
+   * Should be unique and same as HWID
+   */
+  public static final int DEFAULT_ADDRESS = 0x000E;
 
   /**
-   * Hardware ID (Should be unique) -- NEEDS TO BE CHANGED
+   * Hardware ID (Should be unique)
    */
-  public static final char HWID = 0x010F;
+  public static final char HWID = 0x000E;
 
   /**
    * Radiation Constants

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadiationDetector.java
@@ -36,8 +36,13 @@ public class RadiationDetector extends HardwareModule {
   }
 
   /**
-   * Find tiles between two given coordinates.
+   * Finds the tiles between the two tiles located at the given coordinates. The
+   * tiles located at the coordinates are not included in the list.
    * 
+   * @param x0 x-coordinate of first point
+   * @param y0 y-coordinate of first point
+   * @param x1 x-coordinate of second point
+   * @param y1 y-coordinate of second point
    * @return List of tile coordinates. An empty list indicates tiles are next to
    *         each other.
    */
@@ -93,6 +98,19 @@ public class RadiationDetector extends HardwareModule {
     }
 
     return ret;
+  }
+
+  /**
+   * Finds the Euclidean Distance between two coordinates.
+   * 
+   * @param x0 x-coordinate of first point
+   * @param y0 y-coordinate of first point
+   * @param x1 x-coordinate of second point
+   * @param y1 y-coordinate of second point
+   * @return distance between two points
+   */
+  public double getDistanceOfCoords(int x0, int y0, int x1, int y1) {
+    return Math.sqrt(Math.pow(x1 - x0, 2) + Math.pow(y1 - y0, 2));
   }
 
   public RadiationDetector(ControllableUnit unit) {

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadioactiveWorldUtils.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/RadioactiveWorldUtils.java
@@ -1,0 +1,77 @@
+package net.simon987.pluginradioactivecloud;
+
+import net.simon987.server.game.world.TileMap;
+import net.simon987.server.game.world.TilePlain;
+import net.simon987.server.game.world.World;
+import org.bson.types.ObjectId;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Random;
+
+public class RadioactiveWorldUtils {
+
+  /**
+   * Generate a list of biomass blobs for a world
+   */
+  public static ArrayList<RadioactiveObstacle> generateRadioactiveObstacles(World world, int minCount, int maxCount) {
+
+    Random random = new Random();
+    int radioactiveObjCount = random.nextInt(maxCount - minCount) + minCount;
+    ArrayList<RadioactiveObstacle> radioactiveObstacles = new ArrayList<>(radioactiveObjCount);
+
+    // Count number of plain tiles. If there is less plain tiles than desired amount
+    // of radioactive objects, set the desired amount of radioactive objects to the
+    // plain tile count
+    TileMap m = world.getTileMap();
+    int plainCount = 0;
+    for (int y = 0; y < world.getWorldSize(); y++) {
+      for (int x = 0; x < world.getWorldSize(); x++) {
+
+        if (m.getTileIdAt(x, y) == TilePlain.ID) {
+          plainCount++;
+        }
+      }
+    }
+
+    if (radioactiveObjCount > plainCount) {
+      radioactiveObjCount = plainCount;
+    }
+
+    outerLoop: for (int i = 0; i < radioactiveObjCount; i++) {
+
+      Point p = m.getRandomTile(TilePlain.ID);
+      if (p != null) {
+
+        // Don't block worlds
+        int counter = 0;
+        while (p.x == 0 || p.y == 0 || p.x == world.getWorldSize() - 1 || p.y == world.getWorldSize() - 1
+            || world.getGameObjectsAt(p.x, p.y).size() != 0) {
+          p = m.getRandomTile(TilePlain.ID);
+          counter++;
+
+          if (counter > 25) {
+            continue outerLoop;
+          }
+        }
+
+        for (RadioactiveObstacle radioactiveObstacle : radioactiveObstacles) {
+          if (radioactiveObstacle.getX() == p.x && radioactiveObstacle.getY() == p.y) {
+            // There is already a blob here
+            continue outerLoop;
+          }
+        }
+
+        RadioactiveObstacle radioactiveObstacle = new RadioactiveObstacle();
+        radioactiveObstacle.setObjectId(new ObjectId());
+        radioactiveObstacle.setX(p.x);
+        radioactiveObstacle.setY(p.y);
+        radioactiveObstacle.setWorld(world);
+
+        radioactiveObstacles.add(radioactiveObstacle);
+      }
+    }
+
+    return radioactiveObstacles;
+  }
+}

--- a/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/event/WorldCreationListener.java
+++ b/Plugin Radioactive Cloud/src/main/java/net/simon987/pluginradioactivecloud/event/WorldCreationListener.java
@@ -1,0 +1,32 @@
+package net.simon987.pluginradioactivecloud.event;
+
+import net.simon987.pluginradioactivecloud.RadioactiveObstacle;
+import net.simon987.pluginradioactivecloud.RadioactiveWorldUtils;
+import net.simon987.server.GameServer;
+import net.simon987.server.event.GameEvent;
+import net.simon987.server.event.GameEventListener;
+import net.simon987.server.event.WorldGenerationEvent;
+
+import java.util.ArrayList;
+
+public class WorldCreationListener implements GameEventListener {
+    @Override
+    public Class getListenedEventType() {
+        return WorldGenerationEvent.class;
+    }
+
+    @Override
+    public void handle(GameEvent event) {
+
+        int minCount = GameServer.INSTANCE.getConfig().getInt("min_radioactive_obstacle_count");
+        int maxCount = GameServer.INSTANCE.getConfig().getInt("max_radioactive_obstacle_count");
+
+        ArrayList<RadioactiveObstacle> radioactiveObstacles = RadioactiveWorldUtils
+                .generateRadioactiveObstacles(((WorldGenerationEvent) event).getWorld(), minCount, maxCount);
+
+        for (RadioactiveObstacle radioactiveObstacle : radioactiveObstacles) {
+            ((WorldGenerationEvent) event).getWorld().addObject(radioactiveObstacle);
+        }
+
+    }
+}

--- a/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
+++ b/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
@@ -6,7 +6,7 @@ package net.simon987.server.game.objects;
 
 public interface Radioactive {
 
-  public static int getAlphaCounts(double distance) {
+  public default int getAlphaCounts(double distance) {
     return (int) (1000 * 1.0 / (distance * distance));
   }
 }

--- a/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
+++ b/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
@@ -6,5 +6,7 @@ package net.simon987.server.game.objects;
 
 public interface Radioactive {
 
-
+  public static int getAlphaCounts(double distance) {
+    return (int) (1000 * 1.0 / (distance * distance));
+  }
 }

--- a/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
+++ b/Server/src/main/java/net/simon987/server/game/objects/Radioactive.java
@@ -9,4 +9,12 @@ public interface Radioactive {
   public default int getAlphaCounts(double distance) {
     return (int) (1000 * 1.0 / (distance * distance));
   }
+
+  public default int getBetaCounts(double distance) {
+    return (int) (2000 * 1.0 / (distance * distance));
+  }
+
+  public default int getGammaCounts(double distance) {
+    return (int) (5000 * 1.0 / (distance * distance));
+  }
 }

--- a/Server/src/main/resources/config.properties
+++ b/Server/src/main/resources/config.properties
@@ -94,6 +94,8 @@ electric_box_energy_given=70
 #RadioactiveObstacle
 radioactive_obstacle_corruption_block_size=10
 radioactive_cloud_corruption_block_size=40
+min_radioactive_obstacle_count=0
+max_radioactive_obstacle_count=1
 
 #SecretKey
 secret_key=<your_secret_key>


### PR DESCRIPTION
It should be adding the Radioactive Obstacle onto the map from the World Creation Listener event. I don't think the Radioactive Obstacle has artwork, so it doesn't actually display on the map. Makes progress on issue #135.

Questions I have:
- Where can I look to see artwork being displayed on the map?
- How do I decipher the world in the logs? For example, the RadioactiveObstacle has a MAP_INFO of 0x0A01 and it should be currently displayed. How can I tell if it is there in the following log?

```
F8 41 00 01 F8 09 00 04 F8 41 00 02 F8 8C 00 57 F8
0E 02 2B F8 8C 00 53 F8 0E 02 31 F8 8C 00 41 F8 0E
02 3D F8 8C 00 44 F8 0E 02 37 F8 8C 00 45 F8 0E 02
43 F8 8C 00 49 F8 0E 02 49 F8 8C 00 43 F8 0E 02 53
F8 8C 00 46 F8 0E 02 59 F8 41 00 00 F8 09 00 04 00
00 F8 81 00 00 F8 09 00 01 F8 0A 02 26 F8 81 00 02
F8 09 00 01 F8 0A 02 26 F8 81 00 01 F8 09 00 01 F8
0A 02 26 F8 81 00 03 F8 09 00 01 F8 0A 02 26 F8 41
00 02 F8 09 00 05 F8 0A 02 26 F8 41 00 01 F8 09 00
06 F8 41 00 01 F8 09 00 09 F8 0A 02 26 F8 41 00 00
F8 09 00 06 F8 0A 02 26 F8 81 00 01 F8 41 00 01 F8
09 00 02 F8 0A 02 26
```