### PR TITLE
Update installation guide on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ sudo apt install git maven openjdk-8-jdk mongodb
 
 On Arch:
 ``` bash
-sudo pacman -S git maven mongodb jdk8-opendjk
+sudo pacman -S git maven jdk8-opendjk
+yay -S mongodb-bin
 
 # Don't forget to start mongodb
 sudo systemctl start mongodb.service
 ```
 
-*If needed, visit [troubleshooting mongodb](https://wiki.archlinux.org/index.php/MongoDB#Troubleshooting).*
+*If needed, visit [yay installation](https://github.com/Jguer/yay#installation) and [troubleshooting mongodb](https://wiki.archlinux.org/index.php/MongoDB#Troubleshooting).*
 
 **Deploying server**
 


### PR DESCRIPTION
Change the package manager from pacman to yay which installs mongodb.

Beginning with January 2019 mongodb package is not available in the official Arch repositories and can't be installed using pacman. Instead of pacman you can use yay to compile mongodb or install prebuilt mongodb-bin. To compile mongodb you should have 260 GB available on your hard disk, so mongodb-bin is easier to install.

As a result, guide is now correct for Arch Linux users.