### PR TITLE
Remove dead URI muchassemblyrequired.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### [Official website](https://muchassemblyrequired.com)
+# Much-Assembly-Required
 
 [![CodeFactor](https://www.codefactor.io/repository/github/simon987/much-assembly-required/badge)](https://www.codefactor.io/repository/github/simon987/much-assembly-required)
 [![Build Status](https://ci.simon987.net/buildStatus/icon?job=Much-Assembly-Required)](https://ci.simon987.net/job/Much-Assembly-Required/)


### PR DESCRIPTION
The website muchassemblyrequired.com no longer points to anything related to this repo.

I suggest also removing the URI from the description.